### PR TITLE
- Fix for a breaking change in `puppet-stdlib` version 8.3.0 (https:/…

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,34 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.sync.yml
+++ b/.sync.yml
@@ -36,7 +36,9 @@ appveyor.yml:
       collection: puppet7
     - set: ubuntu1604-64
       collection: puppet6
-    - set: ubuntu1404-64
+    - set: debian11-64
+      collection: puppet7
+    - set: debian11-64
       collection: puppet6
     - set: debian10-64
       collection: puppet7

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,16 @@ jobs:
     -
       bundler_args: --with system_tests
       dist: focal
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=ubuntu1404-64 BEAKER_TESTMODE=apply
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_setfile=debian11-64 BEAKER_TESTMODE=apply
+      rvm: 2.5.7
+      script: bundle exec rake beaker
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      bundler_args: --with system_tests
+      dist: focal
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=debian11-64 BEAKER_TESTMODE=apply
       rvm: 2.5.7
       script: bundle exec rake beaker
       services: docker

--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,7 @@ end
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.fail_on_warnings = true
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -3,6 +3,8 @@ class dockctl::dependencies () inherits dockctl {
   assert_private("Use of private class ${name} by ${caller_module_name}")
 
   if $dockctl::git_manage {
-    ensure_packages([$dockctl::git_package], { 'ensure' => $dockctl::ensure })
+    package { [$dockctl::git_package]:
+      ensure => $dockctl::ensure,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04",
         "18.04",
         "20.04"
@@ -105,7 +104,7 @@
     "compose",
     "container management"
   ],
-  "pdk-version": "2.2.0",
-  "template-url": "pdk-default#2.2.0",
-  "template-ref": "tags/2.2.0-0-g2381db6"
+  "pdk-version": "2.4.0",
+  "template-url": "pdk-default#2.4.0",
+  "template-ref": "tags/2.4.0-0-gfa6b6d2"
 }


### PR DESCRIPTION
…/github.com/puppetlabs/puppetlabs-stdlib/pull/1196)

- Updated `pdk` template version.
- Added unit test coverage for Debian 11.
- Removed test coverage for Ubuntu 14.04.